### PR TITLE
fix: Counterexamples are no longer cut off

### DIFF
--- a/propcheck.el
+++ b/propcheck.el
@@ -673,7 +673,7 @@ inputs found will be reported."
          (when found-seed
            (let ((propcheck--replay '(())))
              (propcheck--funcall-with-seed ,fun-sym found-seed)
-             (ert-fail (list "Found counterexample" (car propcheck--replay)))))))))
+             (ert-fail (list "Found counterexample" (butlast propcheck--replay)))))))))
 
 (provide 'propcheck)
 ;;; propcheck.el ends here

--- a/propcheck.el
+++ b/propcheck.el
@@ -45,6 +45,7 @@
 (defvar propcheck-max-shrinks 200)
 (defvar propcheck--shrinks-remaining nil)
 (defvar propcheck--replay nil)
+(defvar propcheck--test-err-condition nil)
 
 (defvar propcheck-seed
   nil
@@ -361,9 +362,10 @@ If a counterexample is found, return the final seed."
          (propcheck--no-intervals seed)))
     (catch 'propcheck--counterexample
       (catch 'propcheck--overrun
-        (condition-case nil
+        (condition-case test-err-condition
             (funcall fun)
           (error
+	   (setq propcheck--test-err-condition test-err-condition)
            ;; Consider an error to be another counterexample.
            (throw 'propcheck--counterexample propcheck-seed))))
       nil)))
@@ -671,9 +673,10 @@ inputs found will be reported."
               (found-seed
                (propcheck--find-small-counterexample ,fun-sym)))
          (when found-seed
-           (let ((propcheck--replay '(())))
+           (let ((propcheck--replay '(()))
+		 (propcheck--test-execution-errors nil))
              (propcheck--funcall-with-seed ,fun-sym found-seed)
-             (ert-fail (list "Found counterexample" (butlast propcheck--replay)))))))))
-
+             (ert-fail (list "Found counterexample" (butlast propcheck--replay)
+			     "Test execution errors:" propcheck--test-err-condition))))))))
 (provide 'propcheck)
 ;;; propcheck.el ends here

--- a/propcheck.el
+++ b/propcheck.el
@@ -353,6 +353,12 @@ Note that elisp does not have a separate character type."
     (throw 'propcheck--counterexample
            propcheck-seed)))
 
+(defun propcheck-should-not (invalid-p)
+    (when invalid-p
+      (throw 'propcheck--counterexample
+  	   propcheck-seed)))
+
+
 (defun propcheck--funcall-with-seed (fun seed)
   "Call FUN with SEED used to generate inputs.
 If a counterexample is found, return the final seed."

--- a/test/propcheck-unit-test.el
+++ b/test/propcheck-unit-test.el
@@ -365,20 +365,6 @@ This is intended for manual testing. Try calling it inside an ielm buffer."
          examples)))
     examples))
 
-(ert-deftest propcheck-shrinking-buggy-zerop ()
-  "Ensure that we find the minimal counterexample for
-`propcheck--buggy-zerop'."
-  (let ((optimal-count 0))
-    (dotimes (_ 10)
-      (let* ((found-seed
-              (propcheck--find-small-counterexample #'propcheck--buggy-zerop-test))
-             (propcheck-seed found-seed)
-             (propcheck--replay t)
-             (i (propcheck-generate-integer nil)))
-        (when (= i 1)
-          (cl-incf optimal-count))))
-    ;; We should get the optimal result at least 90% of the time.
-    (should (>= optimal-count 9))))
 
 (defun propcheck--buggy-max-item (items)
   (car items))


### PR DESCRIPTION
Whenever a test with multiple generators failed, the counterexample only showed the value that was generated by the first one. Now, if multiple generators are used, the counterexample will include all of the generated values. 